### PR TITLE
Add option for blocking calls with UdpServer and UdpClient classes

### DIFF
--- a/include/udp_client_server/udp_client_server.h
+++ b/include/udp_client_server/udp_client_server.h
@@ -39,7 +39,7 @@ public:
 class UdpClient
 {
 public:
-                        UdpClient(const std::string& addr, int port);
+                        UdpClient(const std::string& addr, int port, bool blocking);
                         ~UdpClient();
 
     int                 getSocket() const;
@@ -59,7 +59,7 @@ private:
 class UdpServer
 {
 public:
-                        UdpServer(const std::string& addr, int port);
+                        UdpServer(const std::string& addr, int port, bool blocking);
                         ~UdpServer();
 
     int                 getSocket() const;

--- a/include/udp_client_server/udp_client_server.h
+++ b/include/udp_client_server/udp_client_server.h
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+// 
+// Modified: Joshua Holden Turner, 2024
 
 #ifndef SNAP_UDP_CLIENT_SERVER_H
 #define SNAP_UDP_CLIENT_SERVER_H

--- a/include/udp_client_server/udp_client_server.h
+++ b/include/udp_client_server/udp_client_server.h
@@ -41,7 +41,7 @@ public:
 class UdpClient
 {
 public:
-                        UdpClient(const std::string& addr, int port, bool blocking);
+                        UdpClient(const std::string& addr, int port, bool blocking = false);
                         ~UdpClient();
 
     int                 getSocket() const;
@@ -61,7 +61,7 @@ private:
 class UdpServer
 {
 public:
-                        UdpServer(const std::string& addr, int port, bool blocking);
+                        UdpServer(const std::string& addr, int port, bool blocking = false);
                         ~UdpServer();
 
     int                 getSocket() const;

--- a/src/udp_client_server.cpp
+++ b/src/udp_client_server.cpp
@@ -63,7 +63,7 @@ namespace udp_client_server
  * \param[in] port      The port number.
  * \param[in] blocking  Whether or not the socket is blocking
  */
-UdpClient::UdpClient(const std::string& addr, int port, bool blocking = false)
+UdpClient::UdpClient(const std::string& addr, int port, bool blocking)
     : f_port_(port)
     , f_addr_(addr)
 {
@@ -199,7 +199,7 @@ int UdpClient::send(const char *msg, size_t size)
  *      to false, if true, then the UdpServer::recv(...) command will not 
  *      return until the specified number of bytes has been read.
  */
-UdpServer::UdpServer(const std::string& addr, int port, bool blocking = false)
+UdpServer::UdpServer(const std::string& addr, int port, bool blocking)
     : f_port_(port)
     , f_addr_(addr)
 {

--- a/src/udp_client_server.cpp
+++ b/src/udp_client_server.cpp
@@ -19,6 +19,8 @@
 // Reformated variable/method names to match the vanderbot_control style guide. 
 // Make all UDP sockets non-blocking
 // Andrew Orekhov, ARMA Lab, 2021
+//
+// Modified: Joshua Holden Turner, 2024
 
 #ifndef SNAP_UDP_CLIENT_SERVER_CPP
 #define SNAP_UDP_CLIENT_SERVER_CPP
@@ -57,8 +59,9 @@ namespace udp_client_server
  * resolved, the port is incompatible or not available, or the socket could
  * not be created.
  *
- * \param[in] addr  The address to convert to a numeric IP.
- * \param[in] port  The port number.
+ * \param[in] addr      The address to convert to a numeric IP.
+ * \param[in] port      The port number.
+ * \param[in] blocking  Whether or not the socket is blocking
  */
 UdpClient::UdpClient(const std::string& addr, int port, bool blocking = false)
     : f_port_(port)
@@ -190,8 +193,11 @@ int UdpClient::send(const char *msg, size_t size)
  * and port combinaison cannot be resolved or if the socket cannot be
  * opened.
  *
- * \param[in] addr  The address we receive on.
- * \param[in] port  The port we receive from.
+ * \param[in] addr      The address we receive on.
+ * \param[in] port      The port we receive from.
+ * \param[in] blocking  Whether or not the socket is blocking, defaults 
+ *      to false, if true, then the UdpServer::recv(...) command will not 
+ *      return until the specified number of bytes has been read.
  */
 UdpServer::UdpServer(const std::string& addr, int port, bool blocking = false)
     : f_port_(port)

--- a/src/udp_client_server.cpp
+++ b/src/udp_client_server.cpp
@@ -60,7 +60,7 @@ namespace udp_client_server
  * \param[in] addr  The address to convert to a numeric IP.
  * \param[in] port  The port number.
  */
-UdpClient::UdpClient(const std::string& addr, int port)
+UdpClient::UdpClient(const std::string& addr, int port, bool blocking = false)
     : f_port_(port)
     , f_addr_(addr)
 {
@@ -77,7 +77,7 @@ UdpClient::UdpClient(const std::string& addr, int port)
     {
         throw UdpClientServerRuntimeError(("invalid address or port: \"" + addr + ":" + decimal_port + "\"").c_str());
     }
-    f_socket_ = socket(f_addrinfo_->ai_family, SOCK_DGRAM | SOCK_CLOEXEC | SOCK_NONBLOCK, IPPROTO_UDP);
+    f_socket_ = socket(f_addrinfo_->ai_family, SOCK_DGRAM | SOCK_CLOEXEC | (blocking ? 0x00: SOCK_NONBLOCK), IPPROTO_UDP);
     if(f_socket_ == -1)
     {
         freeaddrinfo(f_addrinfo_);
@@ -193,7 +193,7 @@ int UdpClient::send(const char *msg, size_t size)
  * \param[in] addr  The address we receive on.
  * \param[in] port  The port we receive from.
  */
-UdpServer::UdpServer(const std::string& addr, int port)
+UdpServer::UdpServer(const std::string& addr, int port, bool blocking = false)
     : f_port_(port)
     , f_addr_(addr)
 {
@@ -210,7 +210,7 @@ UdpServer::UdpServer(const std::string& addr, int port)
     {
         throw UdpClientServerRuntimeError(("invalid address or port for UDP socket: \"" + addr + ":" + decimal_port + "\"").c_str());
     }
-    f_socket_ = socket(f_addrinfo_->ai_family, SOCK_DGRAM | SOCK_CLOEXEC | SOCK_NONBLOCK, IPPROTO_UDP);
+    f_socket_ = socket(f_addrinfo_->ai_family, SOCK_DGRAM | SOCK_CLOEXEC | (blocking? 0x00 : SOCK_NONBLOCK), IPPROTO_UDP);
     if(f_socket_ == -1)
     {
         freeaddrinfo(f_addrinfo_);


### PR DESCRIPTION
Added the option to enable/disable blocking sockets for UDP send/receive classes. Defaults to false (non-blocking) for both and therefore is compatible with prior code.